### PR TITLE
Fix repo references after moving to edison-fw org

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,4 +27,4 @@ Currently I am tracking origin/master but I have created four additional branche
 
 # How to use this
 
-Yocto Morty / Pyro will build on Ubuntu Artful (17.10). For detailed instructions see the wiki [https://github.com/htot/meta-intel-edison/wiki](https://github.com/htot/meta-intel-edison/wiki)
+Yocto Morty / Pyro will build on Ubuntu Artful (17.10). For detailed instructions see the wiki [https://github.com/edison-fw/meta-intel-edison/wiki](https://github.com/edison-fw/meta-intel-edison/wiki)

--- a/meta-intel-edison-bsp/recipes-bsp/u-boot/u-boot-common_2018.05.inc
+++ b/meta-intel-edison-bsp/recipes-bsp/u-boot/u-boot-common_2018.05.inc
@@ -25,7 +25,7 @@ EDISON-PATCHES = "\
 "
 
 SRC_URI = "${@bb.utils.contains('DISTRO_FEATURES', \
-	'acpi', 'git://github.com/htot/u-boot.git;branch=acpi-v2018.05;protocol=https', \
+	'acpi', 'git://github.com/edison-fw/u-boot.git;branch=acpi-v2018.05;protocol=https', \
 		'git://github.com/u-boot/u-boot.git;branch=master;protocol=https', d)}"
 		
 SRCREV = "${@bb.utils.contains('DISTRO_FEATURES', \

--- a/meta-intel-edison-bsp/recipes-kernel/linux/linux-yocto_4.16.0.bb
+++ b/meta-intel-edison-bsp/recipes-kernel/linux/linux-yocto_4.16.0.bb
@@ -8,7 +8,7 @@ require recipes-kernel/linux/linux-yocto.inc
 PV = "4.16.0"
 
 # this branch now contains both non-acpi kernel and acpi enabled kernel on top
-SRC_URI = "git://github.com/htot/linux.git;protocol=https;branch=eds-4.16.0-unified \
+SRC_URI = "git://github.com/edison-fw/linux.git;protocol=https;branch=eds-4.16.0-unified \
         file://ftdi_sio.cfg \
         file://smsc95xx.cfg \
         file://bt_more.cfg \

--- a/setup.sh
+++ b/setup.sh
@@ -283,7 +283,7 @@ COPYLEFT_LICENSE_INCLUDE = 'GPL* LGPL*'
   do_update_cache "meta-intel" "git://git.yoctoproject.org"
   do_update_cache "meta-mingw" "git://git.yoctoproject.org"
   do_update_cache "meta-darwin" "git://git.yoctoproject.org"
-  do_update_cache "meta-acpi" "https://github.com/htot"
+  do_update_cache "meta-acpi" "https://github.com/edison-fw"
 
   cd $my_build_dir
   poky_dir=$my_build_dir/poky


### PR DESCRIPTION
I've not corrected all of the references in `README.md` on purpose - as those currently left are about `meta-intel-iot-middleware` layer, which we don't use any more anyway and it's just that the whole readme needs an overhaul. I'll send a PR proposal later.

Other than that there were just a few fixes. The build is still running for me, so @htot, please don't merge it just yet - for now please take a look and tell me if it looks ok for you. When my build is [successfully] done, I'll merge it.