### PR TITLE
linux-yocto: fix failure upon the first kernel build after setup

### DIFF
--- a/meta-intel-edison-bsp/recipes-kernel/linux/linux-yocto_4.16.0.bb
+++ b/meta-intel-edison-bsp/recipes-kernel/linux/linux-yocto_4.16.0.bb
@@ -33,3 +33,12 @@ LINUX_VERSION ?= "4.16.0"
 
 
 COMPATIBLE_MACHINE = "edison"
+
+# Fix a bug where "make alldefconfig" run triggered by merge_config.sh doesn't find bison.
+# This is just a band aid and should probably be brought to Yocto mail list for fixing/clarification.
+# They added a patch for this a while ago, setting explicit dependency on bison-native,
+# but (1) here we have it anyway and (2) I don't see how it can help as DEPENDS only sets a link
+# between do_configure and do_populate_sysroot and do_kernel_configme runs before do_configure.
+# https://git.yoctoproject.org/cgit.cgi/poky/commit/meta/classes/kernel.bbclass?id=20e4d309e12bf10e2351e0016b606e85599b80f6
+do_kernel_configme[depends] = "bison-native:do_populate_sysroot"
+


### PR DESCRIPTION
I've spent some time chasing that first kernel build problem we discussed in #23 and I think I finally found the root cause, so here comes the fix. Below is the commit message with detailed description. I've build-tested it multiple times (with cleanups as well as clean env setup from scratch) and it works ok now. This is more like a workaround, that's why I've added a detailed comment as well as this commit message. At some point we will probably want to discuss this with Yocto folks, but for now there's bigger fish to fry.

-----
After setting up the build env for the first time or a full cleanup,
the kernel build fails with

|   CC      scripts/mod/empty.o
| cc1: error: code model 'kernel' not supported in the 32 bit mode
| cc1: sorry, unimplemented: 64-bit mode not compiled in

This is caused by the fact that .config is created completely
incorrectly and has 64bit enabled, among other things. This, in turn,
is caused by the fact that "make alldefconfig" called by merge_config.sh
fails not being able to find bison - kernels from 4.16 onwards require it (+flex).

The bison-native package is in the DEPENDS, but is not deployed into sysroot
until right before the do_configure task and merge_config.sh runs
within do_kernel_configme, earlier than that. All subsequent task runs succeed,
because bison is already deployed into the recipe's sysroot.

There's a Yocto commit, which seemingly addresses this problem:

https://git.yoctoproject.org/cgit.cgi/poky/commit/meta/classes/kernel.bbclass?id=20e4d309e12bf10e2351e0016b606e85599b80f6

but doesn't help as it only makes the dependency explicit, but does nothing
w.r.t. the do_configure vs. do_kernel_configme ordering.

So, work this around by adding an explicit dependency between do_kernel_configme
and bison-native's sysroot deployment task. This must be clarified with Yocto folks
in the long run.

Signed-off-by: Alex Tereschenko <alext.mkrs@gmail.com>