### PR TITLE
Fix hostapd conf path - main

### DIFF
--- a/meta-intel-edison-distro/recipes-core/post-install/files/post-install.sh
+++ b/meta-intel-edison-distro/recipes-core/post-install/files/post-install.sh
@@ -31,7 +31,7 @@ sshd_init () {
     systemctl start sshdgenkeys
 }
 
-# Substitute the SSID and passphrase in the file /etc/hostapd/hostapd.conf
+# Substitute the SSID and passphrase in the file /etc/hostapd.conf
 # The SSID is built from the hostname and a serial number to have a
 # unique SSID in case of multiple Edison boards having their WLAN AP active.
 setup_ap_ssid_and_passphrase () {
@@ -43,7 +43,7 @@ setup_ap_ssid_and_passphrase () {
         ssid="EDISON-${wlan0_addr:12:2}-${wlan0_addr:15:2}"
 
         # Substitute the SSID
-        sed -i -e 's/^ssid=.*/ssid='${ssid}'/g' /etc/hostapd/hostapd.conf
+        sed -i -e 's/^ssid=.*/ssid='${ssid}'/g' /etc/hostapd.conf
     fi
 
     if [ -f /factory/serial_number ] ;
@@ -52,7 +52,7 @@ setup_ap_ssid_and_passphrase () {
         passphrase="${factory_serial}"
 
         # Substitute the passphrase
-        sed -i -e 's/^wpa_passphrase=.*/wpa_passphrase='${passphrase}'/g' /etc/hostapd/hostapd.conf
+        sed -i -e 's/^wpa_passphrase=.*/wpa_passphrase='${passphrase}'/g' /etc/hostapd.conf
     fi
 
     sync

--- a/meta-intel-edison-distro/recipes-support/oobe/oobe_git.bb
+++ b/meta-intel-edison-distro/recipes-support/oobe/oobe_git.bb
@@ -1,8 +1,10 @@
 DESCRIPTION="The out-of-box configuration service"
 LICENSE = "MIT"
 
-SRC_URI = "git://github.com/01org/edison-oobe.git;protocol=https"
-SRCREV = "4b5f34eed15d15df33af000e474c453ca35245f0"
+SRC_URI = "git://github.com/edison-fw/edison-oobe.git;protocol=https"
+
+SRCREV = "${AUTOREV}"
+PV = "1.2.1+git${SRCPV}"
 
 LIC_FILES_CHKSUM = "file://LICENSE;md5=ea398a763463b76b18da15f013c0c531"
 


### PR DESCRIPTION
This is the main part of the fix for #24 (the second one is in https://github.com/edison-fw/edison-oobe/pull/1). I've corrected the `hostapd.conf` paths in those scripts and switched to using our copy of the `edison-oobe` repo.

Build-tested on current master.