### PR TITLE
Add layerseries compat

### DIFF
--- a/meta-intel-edison-bsp/conf/layer.conf
+++ b/meta-intel-edison-bsp/conf/layer.conf
@@ -9,5 +9,4 @@ BBFILE_COLLECTIONS += "intel-edison-bsp"
 BBFILE_PATTERN_intel-edison-bsp = "^${LAYERDIR}/"
 BBFILE_PRIORITY_intel-edison-bsp = "6"
 
-PREFERRED_PROVIDER_virtual/kernel = "linux-yocto"
-PREFERRED_VERSION_linux-yocto = "4.13.0%"
+LAYERSERIES_COMPAT_intel-edison-bsp = "rocko sumo"

--- a/meta-intel-edison-bsp/conf/layer.conf
+++ b/meta-intel-edison-bsp/conf/layer.conf
@@ -5,9 +5,9 @@ BBPATH := "${BBPATH}:${LAYERDIR}"
 BBFILES := "${BBFILES} ${LAYERDIR}/recipes-*/*/*.bb \
 	${LAYERDIR}/recipes-*/*/*.bbappend"
 
-BBFILE_COLLECTIONS += "intel-edison"
-BBFILE_PATTERN_intel-edison = "^${LAYERDIR}/"
-BBFILE_PRIORITY_intel-edison = "6"
+BBFILE_COLLECTIONS += "intel-edison-bsp"
+BBFILE_PATTERN_intel-edison-bsp = "^${LAYERDIR}/"
+BBFILE_PRIORITY_intel-edison-bsp = "6"
 
 PREFERRED_PROVIDER_virtual/kernel = "linux-yocto"
 PREFERRED_VERSION_linux-yocto = "4.13.0%"

--- a/meta-intel-edison-distro/conf/layer.conf
+++ b/meta-intel-edison-distro/conf/layer.conf
@@ -8,3 +8,5 @@ BBFILES := "${BBFILES} ${LAYERDIR}/recipes-*/*/*.bb \
 BBFILE_COLLECTIONS += "intel-edison-distro"
 BBFILE_PATTERN_intel-edison-distro = "^${LAYERDIR}/"
 BBFILE_PRIORITY_intel-edison-distro = "6"
+
+LAYERSERIES_COMPAT_intel-edison-distro = "rocko sumo"


### PR DESCRIPTION
This adds LAYERSERIES_COMPAT statements to fix the sumo warnings + fixes `intel-edison-bsp` layer name in its config + removes obsolete preference settings (those are set in distro/machine config now).