### PR TITLE
Feature reboot arg

### DIFF
--- a/meta-intel-edison-bsp/conf/machine/edison.conf
+++ b/meta-intel-edison-bsp/conf/machine/edison.conf
@@ -6,7 +6,7 @@
 # This sets compilation options close to what is used on android
 include conf/machine/include/tune-core2.inc
 TUNE_CCARGS .= " -mstackrealign"
-#DEFAULTTUNE = "core2-64"
+DEFAULTTUNE = "core2-64"
 
 MACHINE_FEATURES = "bluetooth alsa pci serial usbgadget usbhost wifi x86 ext3"
 KERNEL_IMAGETYPE = "bzImage"
@@ -18,8 +18,7 @@ SERIAL_CONSOLES = "115200;ttyS2"
 UBOOT_MACHINE = "edison_defconfig"
 
 # this tells yocto to use the defconfig supplied with the kernel
-#KBUILD_DEFCONFIG="x86_64_defconfig"
-KBUILD_DEFCONFIG="i386_defconfig"
+KBUILD_DEFCONFIG="x86_64_defconfig"
 # this tells yocto to expand the defconfig, i.e. make defconfig
 KCONFIG_MODE="--alldefconfig"
 

--- a/meta-intel-edison-bsp/recipes-bsp/u-boot/files/edison.env
+++ b/meta-intel-edison-bsp/recipes-bsp/u-boot/files/edison.env
@@ -58,8 +58,14 @@ do_ota_clean=saveenv ; reset
 
 do_ota=run do_ota_init ; run do_load_ota_scr ; run do_source_ota_scr ; run do_ota_clean
 
+# after booting external image we want to return to eMMC on next boot
+clean_bootargs_mode=if env exists bootargs_mode ; then env delete -f bootargs_mode; saveenv; echo "Resetting to default boot mode for next reboot..."; fi ;
+
+# bootargs for external image
+bootargs_common=quiet
+
 # add lines to manual boot alternative kernel and rootfs from sd card
-edsboot=setenv bootargs ${acpi} ${bootargs_edsboot}; run load_edsboot; run boot_edsboot
+edsboot=run clean_bootargs_mode; setenv bootargs ${bootargs_common} ${bootargs_edsboot}; run load_edsboot; run boot_edsboot
 bootargs_edsboot=tty1 console=ttyS2,115200n8 root=/dev/mmcblk1 rootfstype=ext4 systemd.unit=multi-user.target hardware_id=00
 load_edsboot=load mmc 0:9 0x100000 bzImage-initramfs
 boot_edsboot=zboot 0x100000
@@ -67,4 +73,4 @@ boot_edsboot=zboot 0x100000
 # add lines to manual boot alternative kernel and rootfs from usb stick with debug shell after 10 sec
 bootargs_usbboot=debugshell=10 tty1 console=ttyS2,115200n8 root=/dev/sda rootfstype=ext4 systemd.unit=multi-user.target hardware_id=00
 load_usbboot=load mmc 0:9 0x100000 bzImage-initramfs-usb
-usbboot=setenv bootargs ${acpi} ${bootargs_usbboot}; run load_usbboot; run boot_edsboot
+usbboot=run clean_bootargs_mode; setenv bootargs ${bootargs_common} ${bootargs_usbboot}; run load_usbboot; run boot_edsboot

--- a/meta-intel-edison-bsp/recipes-bsp/u-boot/files/edison.env
+++ b/meta-intel-edison-bsp/recipes-bsp/u-boot/files/edison.env
@@ -39,7 +39,7 @@ init_dfu=run do_dfu_alt_info_mmc ; saveenv
 # Handle different boot mode
 bootcmd=echo "Target:${target_name}"; run do_partition; run do_handle_bootargs_mode;
 
-do_handle_bootargs_mode=run do_preprocess_bootargs_mode; if itest.s $bootargs_mode == "ota" ; then run do_ota; fi; if itest.s $bootargs_mode == "boot" ; then run do_boot; fi; if itest.s $bootargs_mode == "flash"; then run do_flash; fi; run do_fallback; exit;
+do_handle_bootargs_mode=run do_preprocess_bootargs_mode; if itest.s $bootargs_mode == "usb" ; then run usbboot; fi; if itest.s $bootargs_mode == "sdhc" ; then run edsboot; fi; if itest.s $bootargs_mode == "ota" ; then run do_ota; fi; if itest.s $bootargs_mode == "boot" ; then run do_boot; fi; if itest.s $bootargs_mode == "flash"; then run do_flash; fi; run do_fallback; exit;
 do_preprocess_bootargs_mode=if env exists bootargs_mode ; then ; else setenv bootargs_mode "boot" ;fi;
 
 do_fallback=echo "Unknown boot mode: $bootargs_mode"; env delete -f bootargs_mode; saveenv; echo "Resetting to default boot mode and reboot..."; reset;

--- a/meta-intel-edison-bsp/recipes-bsp/u-boot/files/edison.env
+++ b/meta-intel-edison-bsp/recipes-bsp/u-boot/files/edison.env
@@ -12,7 +12,7 @@ dfu_alt_info_reset=reset ram 0x0 0x0
 
 # Kernel load configuration
 bootargs_console=console=ttyS2,115200n8 earlyprintk=ttyS2,115200n8,keep
-bootargs_debug=loglevel=4 acpi=off
+bootargs_debug=loglevel=4 acpi=on
 do_bootargs_rootfs=setenv bootargs_rootfs root=/dev/mmcblk0p8 rootfstype=ext4
 first_install_retry=0
 first_install_max_retries=3

--- a/meta-intel-edison-distro/conf/distro/poky-edison.conf
+++ b/meta-intel-edison-distro/conf/distro/poky-edison.conf
@@ -16,7 +16,7 @@ BINDINGS_pn-upm="python nodejs"
 PREFERRED_VERSION_mraa = "1.9%"
 PREFERRED_VERSION_upm = "1.6%"
 
-DISTRO_FEATURES = "systemd alsa argp bluetooth ext2 largefile usbgadget usbhost wifi xattr zeroconf pci pam ${DISTRO_FEATURES_LIBC}"
+DISTRO_FEATURES = "systemd alsa argp bluetooth ext2 largefile usbgadget usbhost wifi xattr zeroconf pci pam acpi ${DISTRO_FEATURES_LIBC}"
 
 # Disable sysvinit for recipes with systemd support
 DISTRO_FEATURES_BACKFILL_CONSIDERED += "sysvinit"

--- a/meta-intel-edison-distro/recipes-core/systemd/files/edison-machine-id.service
+++ b/meta-intel-edison-distro/recipes-core/systemd/files/edison-machine-id.service
@@ -1,0 +1,14 @@
+[Unit]
+Description= Generate unique machine-id
+After=systemd-remount-fs.service
+
+[Service]
+Type=oneshot
+ExecStartPre=/bin/umount /etc/machine-id
+ExecStart=/bin/systemd-machine-id-setup
+ExecStartPost=/bin/systemctl disable edison-machine-id
+StandardOutput=journal+console
+
+[Install]
+WantedBy=basic.target
+

--- a/meta-intel-edison-distro/recipes-core/systemd/files/shutdown-journal-before-reboot.patch
+++ b/meta-intel-edison-distro/recipes-core/systemd/files/shutdown-journal-before-reboot.patch
@@ -1,0 +1,10 @@
+diff --git a/units/systemd-reboot.service.in b/units/systemd-reboot.service.in
+index 9565f2c..a6fbb23 100644
+--- a/units/systemd-reboot.service.in
++++ b/units/systemd-reboot.service.in
+@@ -16,3 +16,5 @@ After=shutdown.target umount.target final.target
+ Type=oneshot
+ ExecStart=@SYSTEMCTL@ --force reboot
+ ExecStartPre=/bin/sh -c " if test -e /run/systemd/reboot-param ; then read REBOOTPARAM < /run/systemd/reboot-param ; fw_setenv bootargs_mode $REBOOTPARAM ; fi "
++ExecStartPre=/bin/systemctl stop systemd-journald.socket
++ExecStartPre=/bin/systemctl stop systemd-journald

--- a/meta-intel-edison-distro/recipes-core/systemd/files/systemd-reboot-service.patch
+++ b/meta-intel-edison-distro/recipes-core/systemd/files/systemd-reboot-service.patch
@@ -1,0 +1,9 @@
+diff --git a/units/systemd-reboot.service.in b/units/systemd-reboot.service.in
+index d99bd3e..4517cfe 100644
+--- a/units/systemd-reboot.service.in
++++ b/units/systemd-reboot.service.in
+@@ -15,3 +15,4 @@ After=shutdown.target umount.target final.target
+ [Service]
+ Type=oneshot
+ ExecStart=@SYSTEMCTL@ --force reboot
++ExecStartPre=/bin/sh -c " if test -e /run/systemd/reboot-param ; then read REBOOTPARAM < /run/systemd/reboot-param ; fw_setenv bootargs_mode $REBOOTPARAM ; fi "

--- a/meta-intel-edison-distro/recipes-core/systemd/files/usb0.network
+++ b/meta-intel-edison-distro/recipes-core/systemd/files/usb0.network
@@ -1,0 +1,6 @@
+[Match]
+Name=usb0
+
+[Network]
+Address=192.168.2.15/24
+

--- a/meta-intel-edison-distro/recipes-core/systemd/systemd_%.bbappend
+++ b/meta-intel-edison-distro/recipes-core/systemd/systemd_%.bbappend
@@ -1,5 +1,6 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 SRC_URI += "file://systemd-reboot-service.patch \
+            file://shutdown-journal-before-reboot.patch \
             file://usb0.network \
             file://edison-machine-id.service "
 

--- a/meta-intel-edison-distro/recipes-core/systemd/systemd_%.bbappend
+++ b/meta-intel-edison-distro/recipes-core/systemd/systemd_%.bbappend
@@ -1,0 +1,17 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+SRC_URI += "file://systemd-reboot-service.patch \
+            file://usb0.network \
+            file://edison-machine-id.service "
+
+do_install_append() {
+    # Push the custom conf files on target
+    install -m 0644 ${WORKDIR}/usb0.network ${D}${sysconfdir}/systemd/network
+
+    # enable a custom service to provide a persistant machine-id value to Edison
+    install -d ${D}${sysconfdir}/systemd/system/basic.target.wants
+    install -m 0644 ${WORKDIR}/edison-machine-id.service \
+            ${D}${systemd_unitdir}/system/edison-machine-id.service
+    ln -sf ${systemd_unitdir}/system/edison-machine-id.service \
+            ${D}${sysconfdir}/systemd/system/basic.target.wants/edison-machine-id.service
+
+}


### PR DESCRIPTION
This commit allows you to type `reboot usb` and `reboot sdhc`, which will perform `usbboot` or `edsboot` respectively without the need to interrupt U-Boot from the console.

The advantage is you can reboot from ssh from remote into the image you want (without console).

Other supported bootargs are `boot`, `ota` and `flash` (unchanged from the factory image).

This fixes #45