### PR TITLE
Fix blink led

### DIFF
--- a/meta-intel-edison-bsp/conf/machine/edison.conf
+++ b/meta-intel-edison-bsp/conf/machine/edison.conf
@@ -30,4 +30,4 @@ KCONFIG_MODE="--alldefconfig"
 #KERNEL_MODULE_PROBECONF += "g_multi"
 
 ACPI_TABLES ?= "arduino.asl spidev.asl"
-ACPI_FEATURES ?= "uart_2w i2c spi"
+ACPI_FEATURES ?= "uart_2w i2c"

--- a/meta-intel-edison-distro/conf/distro/poky-edison.conf
+++ b/meta-intel-edison-distro/conf/distro/poky-edison.conf
@@ -25,3 +25,6 @@ VIRTUAL-RUNTIME_init_manager = "systemd"
 # Uncomment to completely disable support for sysv scripts:
 # Build and install bluez5 experimental tools and plugins
 PACKAGECONFIG_pn-bluez5 += "testing tools readline"
+
+# Build python bindings for libgpiod
+PACKAGECONFIG_append_pn-libgpiod = " python3"

--- a/meta-intel-edison-distro/recipes-core/images/core-image-minimal-initramfs.bbappend
+++ b/meta-intel-edison-distro/recipes-core/images/core-image-minimal-initramfs.bbappend
@@ -12,9 +12,13 @@ PACKAGE_INSTALL += " ${@bb.utils.contains('DISTRO_FEATURES', 'acpi', 'acpi-table
 PACKAGE_INSTALL_remove = " initramfs-live-install initramfs-module-install"
 PACKAGE_INSTALL_remove = " initramfs-live-install-efi initramfs-module-install-efi"
 PACKAGE_INSTALL_remove = " kernel-image"
+PACKAGE_INSTALL_remove = " libgpiod-python python3-core libpython3.5m1.0"
 
 ROOTFS_POSTPROCESS_COMMAND += "clobber_unused; "
 
 clobber_unused () {
         rm ${IMAGE_ROOTFS}/boot/*
+# libgpiod2 pulls in python3-core which we don't need
+        rm -r ${IMAGE_ROOTFS}/usr/lib/python3.5/*
+        rm ${IMAGE_ROOTFS}/usr/lib/libpython3.5m.so.1.0
 }

--- a/meta-intel-edison-distro/recipes-support/blink-led/blink-led_0.1.bb
+++ b/meta-intel-edison-distro/recipes-support/blink-led/blink-led_0.1.bb
@@ -8,6 +8,8 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/files/:"
 inherit systemd
 SYSTEMD_SERVICE_${PN} = "blink-led.service"
 
+RDEPENDS_${PN} = "${@bb.utils.contains('DISTRO_FEATURES', 'acpi', 'libgpiod python3', 'python3', d)}"
+
 SRC_URI = "file://blink-led"
 SRC_URI += "file://blink-led.service"
 

--- a/meta-intel-edison-distro/recipes-support/blink-led/files/blink-led
+++ b/meta-intel-edison-distro/recipes-support/blink-led/files/blink-led
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 #
 # Edison LED blinker
@@ -31,12 +31,22 @@ import time
 import argparse
 import signal
 import sys
+import os
+import gpiod
 
 initial_led_state = "high"
+acpi = False
 
 def write_led(value):
-    with open("/sys/class/gpio/gpio40/direction","w") as lf:
-        lf.write(value)
+    if acpi:
+        if value == "high":
+            level = 1
+        else:
+            level = 0
+        led.set_value(level)
+    else:
+        with open("/sys/class/gpio/gpio40/direction","w") as lf:
+            lf.write(value)
 
 def blink_once():
     write_led("low")
@@ -49,18 +59,26 @@ def deinit_led_gpio():
     write_led(initial_led_state)
 
     # Deinit LED GPIO
-    subprocess.call("""
-    echo 40 >/sys/class/gpio/unexport
-    echo 214 >/sys/class/gpio/unexport
-    echo 243 >/sys/class/gpio/unexport
-    echo 261 >/sys/class/gpio/unexport
-    """, shell=True)
+    if acpi:
+        led.release()
+    else:
+        subprocess.call("""
+        echo 40 >/sys/class/gpio/unexport
+        echo 214 >/sys/class/gpio/unexport
+        echo 243 >/sys/class/gpio/unexport
+        echo 261 >/sys/class/gpio/unexport
+        """, shell=True)
 
 def signal_term_handler(signal, frame):
-    print 'Signal intercepted: de-initing LED GPIOs'
+    print('Signal intercepted: de-initing LED GPIOs')
     deinit_led_gpio()
     sys.exit(0)
 
+def set_line(name, value):
+    line = gpiod.find_line(name)
+    line.request(consumer=line.owner().name(), type=gpiod.LINE_REQ_DIR_OUT)
+    line.set_value(value)
+    line.release()
 
 parser = argparse.ArgumentParser(description='Blink the Edison Arduino board LED.')
 parser.add_argument('--frequency', type=float, default=4, help='blink frequency in Hz')
@@ -73,29 +91,43 @@ args = parser.parse_args()
 signal.signal(signal.SIGTERM, signal_term_handler)
 signal.signal(signal.SIGINT, signal_term_handler)
 
-# Init GPIO mux for LED control
-subprocess.call("""
-echo 40 >/sys/class/gpio/export
-echo 214 >/sys/class/gpio/export
-echo 243 >/sys/class/gpio/export
-echo 261 >/sys/class/gpio/export
-echo high >/sys/class/gpio/gpio214/direction
-echo mode0 > /sys/kernel/debug/gpio_debug/gpio40/current_pinmux
-echo low >/sys/class/gpio/gpio243/direction
-echo high >/sys/class/gpio/gpio261/direction
-echo low >/sys/class/gpio/gpio214/direction""", shell=True)
+# Detect ACPI or SFI
+acpi =  os.path.isdir("/sys/firmware/acpi")
 
-# Save current LED value for reverting to proper state at exit
-try:
-    lf =  open("/sys/class/gpio/gpio40/value","r")
-    v = lf.read()
-    lf.close()
-    if v[0] == '0':
+if acpi:
+    set_line('TRI_STATE_ALL', 0)
+    set_line('SPI_CLK_SEL', 0)
+    set_line('MUX18_DIR', 1)
+    set_line('TRI_STATE_ALL', 0)
+    led = gpiod.Chip('gpiochip0').get_line(40)
+    led.request(consumer=led.owner().name(), type=gpiod.LINE_REQ_DIR_OUT)
+    if led.get_value() == 0:
         initial_led_state = "low"
     else:
         initial_led_state = "high"
-except:
-    print "Can't get current LED state"
+else:
+    # Init GPIO mux for LED control
+    subprocess.call("""
+    echo 40 >/sys/class/gpio/export
+    echo 214 >/sys/class/gpio/export
+    echo 243 >/sys/class/gpio/export
+    echo 261 >/sys/class/gpio/export
+    echo high >/sys/class/gpio/gpio214/direction
+    echo low >/sys/class/gpio/gpio243/direction
+    echo high >/sys/class/gpio/gpio261/direction
+    echo low >/sys/class/gpio/gpio214/direction""", shell=True)
+
+    # Save current LED value for reverting to proper state at exit
+    try:
+        lf =  open("/sys/class/gpio/gpio40/value","r")
+        v = lf.read()
+        lf.close()
+        if v[0] == '0':
+            initial_led_state = "low"
+        else:
+            initial_led_state = "high"
+    except:
+        print("Can't get current LED state")
 
 # Blink LED
 if args.duration >= 0:

--- a/meta-intel-edison-distro/recipes-support/libgpiod/libgpiod.inc
+++ b/meta-intel-edison-distro/recipes-support/libgpiod/libgpiod.inc
@@ -1,0 +1,21 @@
+SUMMARY = "C library and tools for interacting with the linux GPIO character device"
+
+LICENSE = "LGPLv2.1+"
+LIC_FILES_CHKSUM = "file://COPYING;md5=2caced0b25dfefd4c601d92bd15116de"
+
+SRC_URI = "https://www.kernel.org/pub/software/libs/libgpiod/${BP}.tar.xz"
+
+inherit autotools pkgconfig
+
+# enable tools
+PACKAGECONFIG ?= "tools"
+
+PACKAGECONFIG[tests] = "--enable-tests,--disable-tests,kmod udev"
+PACKAGECONFIG[tools] = "--enable-tools,--disable-tools,"
+
+PACKAGES =+ " ${PN}-tools"
+
+FILES_${PN}-tools = "${bindir}/*"
+
+RRECOMMENDS_TOOLS = "${@bb.utils.contains('PACKAGECONFIG', 'tools', '${PN}-tools', '',d)}"
+RRECOMMENDS_${PN} += "${RRECOMMENDS_TOOLS}"

--- a/meta-intel-edison-distro/recipes-support/libgpiod/libgpiod_1.1.1.bb
+++ b/meta-intel-edison-distro/recipes-support/libgpiod/libgpiod_1.1.1.bb
@@ -1,0 +1,16 @@
+require libgpiod.inc
+
+DEPENDS += "autoconf-archive-native"
+
+SRC_URI[md5sum] = "e5e946cb01a35e5046a1a7a108d6a96d"
+SRC_URI[sha256sum] = "172fa1544ecb51f37533b3e67862298d50c0a5cc84975f3c0706dc15467f0dfd"
+
+PACKAGECONFIG[cxx] = "--enable-bindings-cxx,--disable-bindings-cxx"
+
+PACKAGECONFIG[python3] = "--enable-bindings-python,--disable-bindings-python,python3,python3-core"
+inherit ${@bb.utils.contains('PACKAGECONFIG', 'python3', 'python3native', '', d)}
+
+PACKAGES =+ "${PN}-python"
+FILES_${PN}-python = "${PYTHON_SITEPACKAGES_DIR}"
+RRECOMMENDS_PYTHON = "${@bb.utils.contains('PACKAGECONFIG', 'python3', '${PN}-python', '',d)}"
+RRECOMMENDS_${PN} += "${RRECOMMENDS_PYTHON}"


### PR DESCRIPTION
This fixes issue #44 (on the acpi enabled kernel pin numbering has changed breaking the blink-led program).

On acpi the preferred way to access gpio is through libgpiod. The blink-led script is python2.7. libgpiod supports python3 bindings, however the sumo provided recipe does not enabled this.
1) get libgpiod from master
2) enabled python3 bindings
3) spi hogs a pin needed for blinking the led, disable spi for now
4) fixup blink-led to run with python3 and switch to using libgpiod when acpi is detected
5) remove python packages from initramfs as we exceed maximum size

I tested this both with and without acpi enabled kernel.

In a later stage I intend to enable kernel led driver for acpi enabled image, with led trigger (timer, heartbeat, morse) which will probably obsolete blink-led as a service. Until then this works and documents how to migrate from sysfs to libgpiod (which we need to do for mraa as well - which is the major obstacle to make acpi enabled image the default).