### PR TITLE
arch: switch to corei7

### DIFF
--- a/meta-intel-edison-bsp/conf/machine/edison.conf
+++ b/meta-intel-edison-bsp/conf/machine/edison.conf
@@ -4,9 +4,9 @@
 #@DESCRIPTION: Machine configuration for edison systems
 
 # This sets compilation options close to what is used on android
-include conf/machine/include/tune-core2.inc
+include conf/machine/include/tune-corei7.inc
 TUNE_CCARGS .= " -mstackrealign"
-#DEFAULTTUNE = "core2-64"
+DEFAULTTUNE = "corei7-32"
 
 MACHINE_FEATURES = "bluetooth alsa pci serial usbgadget usbhost wifi x86 ext3"
 KERNEL_IMAGETYPE = "bzImage"


### PR DESCRIPTION
This fixes an old question you raised:
Edison is known to support corei7 instructions. On Pyro setting tune to corei7-32 caused non-
functioning sdk build.

But on Sumo sdk works fine so switch corei7. Being a slm atom core it is better optimized for 32bits.  Switch tune for sumo32.