### PR TITLE
Add a minimal base image

### DIFF
--- a/meta-intel-edison-bsp/conf/machine/edison.conf
+++ b/meta-intel-edison-bsp/conf/machine/edison.conf
@@ -6,7 +6,7 @@
 # This sets compilation options close to what is used on android
 include conf/machine/include/tune-corei7.inc
 TUNE_CCARGS .= " -mstackrealign"
-DEFAULTTUNE = "corei7-32"
+#DEFAULTTUNE = "corei7-32"
 
 MACHINE_FEATURES = "bluetooth alsa pci serial usbgadget usbhost wifi x86 ext3"
 KERNEL_IMAGETYPE = "bzImage"
@@ -18,8 +18,7 @@ SERIAL_CONSOLES = "115200;ttyS2"
 UBOOT_MACHINE = "edison_defconfig"
 
 # this tells yocto to use the defconfig supplied with the kernel
-#KBUILD_DEFCONFIG="x86_64_defconfig"
-KBUILD_DEFCONFIG="i386_defconfig"
+KBUILD_DEFCONFIG="x86_64_defconfig"
 # this tells yocto to expand the defconfig, i.e. make defconfig
 KCONFIG_MODE="--alldefconfig"
 

--- a/meta-intel-edison-bsp/conf/machine/edison.conf
+++ b/meta-intel-edison-bsp/conf/machine/edison.conf
@@ -4,9 +4,9 @@
 #@DESCRIPTION: Machine configuration for edison systems
 
 # This sets compilation options close to what is used on android
-include conf/machine/include/tune-core2.inc
+include conf/machine/include/tune-corei7.inc
 TUNE_CCARGS .= " -mstackrealign"
-#DEFAULTTUNE = "core2-64"
+DEFAULTTUNE = "corei7-32"
 
 MACHINE_FEATURES = "bluetooth alsa pci serial usbgadget usbhost wifi x86 ext3"
 KERNEL_IMAGETYPE = "bzImage"

--- a/meta-intel-edison-bsp/conf/machine/edison.conf
+++ b/meta-intel-edison-bsp/conf/machine/edison.conf
@@ -30,4 +30,4 @@ KCONFIG_MODE="--alldefconfig"
 #KERNEL_MODULE_PROBECONF += "g_multi"
 
 ACPI_TABLES ?= "arduino.asl spidev.asl"
-ACPI_FEATURES ?= "uart_2w i2c spi"
+ACPI_FEATURES ?= "uart_2w i2c"

--- a/meta-intel-edison-bsp/recipes-bsp/u-boot/files/edison.env
+++ b/meta-intel-edison-bsp/recipes-bsp/u-boot/files/edison.env
@@ -12,7 +12,7 @@ dfu_alt_info_reset=reset ram 0x0 0x0
 
 # Kernel load configuration
 bootargs_console=console=ttyS2,115200n8 earlyprintk=ttyS2,115200n8,keep
-bootargs_debug=loglevel=4 acpi=off
+bootargs_debug=loglevel=4 acpi=on
 do_bootargs_rootfs=setenv bootargs_rootfs root=/dev/mmcblk0p8 rootfstype=ext4
 first_install_retry=0
 first_install_max_retries=3

--- a/meta-intel-edison-distro/conf/distro/poky-edison.conf
+++ b/meta-intel-edison-distro/conf/distro/poky-edison.conf
@@ -25,3 +25,6 @@ VIRTUAL-RUNTIME_init_manager = "systemd"
 # Uncomment to completely disable support for sysv scripts:
 # Build and install bluez5 experimental tools and plugins
 PACKAGECONFIG_pn-bluez5 += "testing tools readline"
+
+# Build python bindings for libgpiod
+PACKAGECONFIG_append_pn-libgpiod = " python3"

--- a/meta-intel-edison-distro/conf/distro/poky-edison.conf
+++ b/meta-intel-edison-distro/conf/distro/poky-edison.conf
@@ -16,7 +16,7 @@ BINDINGS_pn-upm="python nodejs"
 PREFERRED_VERSION_mraa = "1.9%"
 PREFERRED_VERSION_upm = "1.6%"
 
-DISTRO_FEATURES = "systemd alsa argp bluetooth ext2 largefile usbgadget usbhost wifi xattr zeroconf pci pam ${DISTRO_FEATURES_LIBC}"
+DISTRO_FEATURES = "systemd alsa argp bluetooth ext2 largefile usbgadget usbhost wifi xattr zeroconf pci pam acpi ${DISTRO_FEATURES_LIBC}"
 
 # Disable sysvinit for recipes with systemd support
 DISTRO_FEATURES_BACKFILL_CONSIDERED += "sysvinit"

--- a/meta-intel-edison-distro/recipes-core/images/core-image-minimal-initramfs.bbappend
+++ b/meta-intel-edison-distro/recipes-core/images/core-image-minimal-initramfs.bbappend
@@ -19,6 +19,7 @@ ROOTFS_POSTPROCESS_COMMAND += "clobber_unused; "
 clobber_unused () {
         rm ${IMAGE_ROOTFS}/boot/*
         # libgpiod2 pulls in python3-core which we don't need
-        rm -r ${IMAGE_ROOTFS}/usr/lib/python3.5/*
-        rm ${IMAGE_ROOTFS}/usr/lib/libpython3.5m.so.1.0
+        rm -rf ${IMAGE_ROOTFS}/usr/lib/python3.5/*
+        rm -f ${IMAGE_ROOTFS}/usr/lib/libpython3.5m.so.1.0
+
 }

--- a/meta-intel-edison-distro/recipes-core/images/core-image-minimal-initramfs.bbappend
+++ b/meta-intel-edison-distro/recipes-core/images/core-image-minimal-initramfs.bbappend
@@ -12,9 +12,13 @@ PACKAGE_INSTALL += " ${@bb.utils.contains('DISTRO_FEATURES', 'acpi', 'acpi-table
 PACKAGE_INSTALL_remove = " initramfs-live-install initramfs-module-install"
 PACKAGE_INSTALL_remove = " initramfs-live-install-efi initramfs-module-install-efi"
 PACKAGE_INSTALL_remove = " kernel-image"
+PACKAGE_INSTALL_remove = " libgpiod-python python3-core libpython3.5m1.0"
 
 ROOTFS_POSTPROCESS_COMMAND += "clobber_unused; "
 
 clobber_unused () {
         rm ${IMAGE_ROOTFS}/boot/*
+        # libgpiod2 pulls in python3-core which we don't need
+        rm -r ${IMAGE_ROOTFS}/usr/lib/python3.5/*
+        rm ${IMAGE_ROOTFS}/usr/lib/libpython3.5m.so.1.0
 }

--- a/meta-intel-edison-distro/recipes-core/images/edison-image-minimal.bb
+++ b/meta-intel-edison-distro/recipes-core/images/edison-image-minimal.bb
@@ -1,0 +1,82 @@
+DESCRIPTION = "A minimal functional image to run EDISON"
+LIC_FILES_CHKSUM = "file://${COREBASE}/meta/COPYING.MIT;md5=3da9cfbcb788c80a0384361b4de20420"
+LICENSE = "MIT"
+IMAGE_INSTALL = "packagegroup-core-boot  ${CORE_IMAGE_EXTRA_INSTALL}"
+IMAGE_INSTALL_append = " openssh-sftp-server"
+
+IMAGE_LINGUAS = " "
+
+# We don't want to include initrd - we have initramfs instead
+INITRD_LIVE = ""
+
+# Do not use legacy nor EFI BIOS
+PCBIOS = "0"
+# Do not support bootable USB stick
+NOISO = "1"
+# Generate a HDD image
+NOHDD = "0"
+ROOTFS = ""
+
+# Specify rootfs image type
+IMAGE_FSTYPES = "ext4 live"
+
+inherit core-image
+
+# image-live/live-vm-common do not allow to use initramfs kernel
+# and we really want to have one in the generated hddimg file.
+# Otherwise it doesn't boot due to no mmc/sdhc modules being built-in in our setup).
+# There seems to be no standard mechanism for doing that, but the below works.
+KERNEL_IMAGETYPE_pn-edison-image-minimal = "bzImage-initramfs-edison.bin"
+
+IMAGE_ROOTFS_SIZE = "1048576"
+
+IMAGE_FEATURES += "package-management ssh-server-openssh"
+# Allow passwordless root login and postinst logging
+IMAGE_FEATURES += "debug-tweaks"
+
+IMAGE_INSTALL_append = " wireless-tools"
+IMAGE_INSTALL_append = " wpa-supplicant"
+IMAGE_INSTALL_append = " hostapd"
+IMAGE_INSTALL_append = " bluez5"
+IMAGE_INSTALL_append = " kernel-modules"
+IMAGE_INSTALL_append = " iptables"
+IMAGE_INSTALL_append = " libstdc++"
+IMAGE_INSTALL_append = " u-boot-fw-utils"
+IMAGE_INSTALL_append = " file"
+IMAGE_INSTALL_append = " pciutils"
+IMAGE_INSTALL_append = " usbutils"
+IMAGE_INSTALL_append = " lshw"
+IMAGE_INSTALL_append = " ldd"
+IMAGE_INSTALL_append = " i2c-tools"
+IMAGE_INSTALL_append = " watchdog-sample"
+IMAGE_INSTALL_append = " wget"
+IMAGE_INSTALL_append = " sudo"
+
+IMAGE_INSTALL_append = " screen"
+
+# Python and some basic modules
+# removed python-imaging python-pygobject python-dbus 
+IMAGE_INSTALL_append = " python"
+IMAGE_INSTALL_append = " python-argparse"
+
+# Wifi firmware
+# removed modules, already built into kernel
+IMAGE_INSTALL_append = " bcm43340-fw"
+
+# Adds various other tools
+IMAGE_INSTALL_append = " lsof"
+IMAGE_INSTALL_append = " less"
+
+# Those are necessary to manually create partitions and file systems on the eMMC
+IMAGE_INSTALL_append = " parted"
+IMAGE_INSTALL_append = " e2fsprogs-e2fsck e2fsprogs-mke2fs e2fsprogs-tune2fs e2fsprogs-badblocks libcomerr libss libe2p libext2fs dosfstools"
+
+# Time related
+IMAGE_INSTALL_append = " tzdata"
+
+IMAGE_INSTALL_append = " libgpiod"
+
+# Add monitoring tools
+IMAGE_INSTALL_append = " htop"
+
+DEPENDS += "u-boot"

--- a/meta-intel-edison-distro/recipes-core/images/edison-image.bb
+++ b/meta-intel-edison-distro/recipes-core/images/edison-image.bb
@@ -1,75 +1,28 @@
+require edison-image-minimal.bb
+
 DESCRIPTION = "A fully functional image to run EDISON"
-LIC_FILES_CHKSUM = "file://${COREBASE}/meta/COPYING.MIT;md5=3da9cfbcb788c80a0384361b4de20420"
-LICENSE = "MIT"
-IMAGE_INSTALL = "packagegroup-core-boot  ${CORE_IMAGE_EXTRA_INSTALL}"
-IMAGE_INSTALL_append = " openssh-sftp-server"
-
-IMAGE_LINGUAS = " "
-
-# We don't want to include initrd - we have initramfs instead
-INITRD_LIVE = ""
-
-# Do not use legacy nor EFI BIOS
-PCBIOS = "0"
-# Do not support bootable USB stick
-NOISO = "1"
-# Generate a HDD image
-NOHDD = "0"
-ROOTFS = ""
-
-# Specify rootfs image type
-IMAGE_FSTYPES = "ext4 live"
-
-inherit core-image
-
-# image-live/live-vm-common do not allow to use initramfs kernel
-# and we really want to have one in the generated hddimg file.
-# Otherwise it doesn't boot due to no mmc/sdhc modules being built-in in our setup).
-# There seems to be no standard mechanism for doing that, but the below works.
 KERNEL_IMAGETYPE_pn-edison-image = "bzImage-initramfs-edison.bin"
 
-IMAGE_ROOTFS_SIZE = "1048576"
-
-IMAGE_FEATURES += "package-management ssh-server-openssh"
-# Allow passwordless root login and postinst logging
-IMAGE_FEATURES += "debug-tweaks"
 
 IMAGE_INSTALL_append = " connman"
 IMAGE_INSTALL_append = " connman-client"
 IMAGE_INSTALL_append = " connman-tools"
 # IMAGE_INSTALL_append = " connman-init-systemd"
 IMAGE_INSTALL_append = " ap-mode-toggle"
-IMAGE_INSTALL_append = " wireless-tools"
-IMAGE_INSTALL_append = " wpa-supplicant"
-IMAGE_INSTALL_append = " hostapd"
-IMAGE_INSTALL_append = " bluez5-dev"
-IMAGE_INSTALL_append = " bluez5-noinst-tools"
-IMAGE_INSTALL_append = " bluez5-testtools"
-IMAGE_INSTALL_append = " bluez5-obex"
-IMAGE_INSTALL_append = " kernel-modules"
 IMAGE_INSTALL_append = " ethtool"
-IMAGE_INSTALL_append = " iptables"
-IMAGE_INSTALL_append = " libstdc++"
-IMAGE_INSTALL_append = " u-boot-fw-utils"
-IMAGE_INSTALL_append = " file"
-IMAGE_INSTALL_append = " pciutils"
-IMAGE_INSTALL_append = " usbutils"
-IMAGE_INSTALL_append = " lshw"
-IMAGE_INSTALL_append = " ldd"
-IMAGE_INSTALL_append = " i2c-tools"
-IMAGE_INSTALL_append = " watchdog-sample"
 IMAGE_INSTALL_append = " pwr-button-handler"
 IMAGE_INSTALL_append = " blink-led"
 IMAGE_INSTALL_append = " post-install"
 IMAGE_INSTALL_append = " resize-rootfs"
+IMAGE_INSTALL_append = " bluez5-dev"
+IMAGE_INSTALL_append = " bluez5-noinst-tools"
+IMAGE_INSTALL_append = " bluez5-testtools"
+IMAGE_INSTALL_append = " bluez5-obex"
 IMAGE_INSTALL_append = " systemd-analyze"
-IMAGE_INSTALL_append = " wget"
-IMAGE_INSTALL_append = " sudo"
 # Allows to enable open pam feature
 IMAGE_INSTALL_append = " libpam"
 # Allows to enable OpenMP feature
 IMAGE_INSTALL_append = " libgomp"
-IMAGE_INSTALL_append = " screen"
 
 # Add audio firmware
 IMAGE_INSTALL_append = " sst-fw-bin"
@@ -81,26 +34,15 @@ IMAGE_INSTALL_append = " alsa-utils-alsamixer alsa-utils-alsactl alsa-utils-apla
 # Python and some basic modules
 # removed python-imaging python-pygobject python-dbus 
 IMAGE_INSTALL_append = " python"
-IMAGE_INSTALL_append = " python-argparse"
 IMAGE_INSTALL_append = " python-distutils python-pkgutil python-audio python-image python-email python-netserver python-xmlrpc python-ctypes python-html python-json python-compile python-misc python-numbers python-unittest python-pydoc"
 
-# Wifi firmware
-# removed modules, already built into kernel
-IMAGE_INSTALL_append = " bcm43340-fw"
-
-# Provides strace and gdb
-IMAGE_FEATURES += "tools-debug"
 IMAGE_INSTALL_append = " crashlog"
 
-# Clean corrupted journald entries
-IMAGE_INSTALL_append = " cleanjournal"
 
 # Adds various other tools
 IMAGE_INSTALL_append = " tcpdump"
 IMAGE_INSTALL_append = " net-tools"
-IMAGE_INSTALL_append = " lsof"
 IMAGE_INSTALL_append = " iperf3"
-IMAGE_INSTALL_append = " less"
 
 # Add pulseaudio
 IMAGE_INSTALL_append = " pulseaudio-server libpulsecore libpulsecommon libpulse libpulse-simple pulseaudio-misc"
@@ -108,20 +50,12 @@ IMAGE_INSTALL_append = " pulseaudio-server libpulsecore libpulsecommon libpulse 
 #Add Gstreamer
 IMAGE_INSTALL_append = " gstreamer1.0 gstreamer1.0-meta-base gstreamer1.0-meta-audio"
 
-# Those are necessary to manually create partitions and file systems on the eMMC
-IMAGE_INSTALL_append = " parted"
-IMAGE_INSTALL_append = " e2fsprogs-e2fsck e2fsprogs-mke2fs e2fsprogs-tune2fs e2fsprogs-badblocks libcomerr libss libe2p libext2fs dosfstools"
-
-# Time related
-IMAGE_INSTALL_append = " tzdata"
-
 # SWIG
 IMAGE_INSTALL_append = " swig"
 
 
 # Edison Arduino stuff
 #IMAGE_INSTALL_append = " clloader"
-IMAGE_INSTALL_append = " libgpiod"
 
 # Edison Middleware stuff
 IMAGE_INSTALL_append = " packagegroup-core-buildessential"
@@ -168,9 +102,15 @@ IMAGE_INSTALL_append = " sketch-check"
 # package management - where to find this?
 #IMAGE_INSTALL_append = " aptitude"
 
+# Provides strace and gdb
+IMAGE_FEATURES += "tools-debug"
+
+# SWIG
+IMAGE_INSTALL_append = " swig"
+
 # Add monitoring tools
-IMAGE_INSTALL_append = " htop"
 IMAGE_INSTALL_append = " iotop"
 IMAGE_INSTALL_append = " powertop"
 
-DEPENDS += "u-boot"
+# Clean corrupted journald entries
+IMAGE_INSTALL_append = " cleanjournal"

--- a/meta-intel-edison-distro/recipes-support/blink-led/blink-led_0.1.bb
+++ b/meta-intel-edison-distro/recipes-support/blink-led/blink-led_0.1.bb
@@ -8,6 +8,8 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/files/:"
 inherit systemd
 SYSTEMD_SERVICE_${PN} = "blink-led.service"
 
+RDEPENDS_${PN} = "${@bb.utils.contains('DISTRO_FEATURES', 'acpi', 'libgpiod python3', 'python3', d)}"
+
 SRC_URI = "file://blink-led"
 SRC_URI += "file://blink-led.service"
 

--- a/meta-intel-edison-distro/recipes-support/blink-led/files/blink-led
+++ b/meta-intel-edison-distro/recipes-support/blink-led/files/blink-led
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 #
 # Edison LED blinker
@@ -31,12 +31,22 @@ import time
 import argparse
 import signal
 import sys
+import os
+import gpiod
 
 initial_led_state = "high"
+acpi = False
 
 def write_led(value):
-    with open("/sys/class/gpio/gpio40/direction","w") as lf:
-        lf.write(value)
+    if acpi:
+        if value == "high":
+            level = 1
+        else:
+            level = 0
+        led.set_value(level)
+    else:
+        with open("/sys/class/gpio/gpio40/direction","w") as lf:
+            lf.write(value)
 
 def blink_once():
     write_led("low")
@@ -49,23 +59,31 @@ def deinit_led_gpio():
     write_led(initial_led_state)
 
     # Deinit LED GPIO
-    subprocess.call("""
-    echo 40 >/sys/class/gpio/unexport
-    echo 214 >/sys/class/gpio/unexport
-    echo 243 >/sys/class/gpio/unexport
-    echo 261 >/sys/class/gpio/unexport
-    """, shell=True)
+    if acpi:
+        led.release()
+    else:
+        subprocess.call("""
+        echo 40 >/sys/class/gpio/unexport
+        echo 214 >/sys/class/gpio/unexport
+        echo 243 >/sys/class/gpio/unexport
+        echo 261 >/sys/class/gpio/unexport
+        """, shell=True)
 
 def signal_term_handler(signal, frame):
-    print 'Signal intercepted: de-initing LED GPIOs'
+    print("Signal intercepted: de-initing LED GPIOs")
     deinit_led_gpio()
     sys.exit(0)
 
+def set_line(name, value):
+    line = gpiod.find_line(name)
+    line.request(consumer=line.owner().name(), type=gpiod.LINE_REQ_DIR_OUT)
+    line.set_value(value)
+    line.release()
 
-parser = argparse.ArgumentParser(description='Blink the Edison Arduino board LED.')
-parser.add_argument('--frequency', type=float, default=4, help='blink frequency in Hz')
-parser.add_argument('--duration',  type=float, default=-1, help='duration of the blink in seconds. Negative value means no timeout, i.e. it will stop when the program is killed.')
-parser.add_argument('--duty_cycle',  type=float, default=0.5, help='duty cycle between 0 and 1')
+parser = argparse.ArgumentParser(description="Blink the Edison Arduino board LED.")
+parser.add_argument("--frequency", type=float, default=4, help="blink frequency in Hz")
+parser.add_argument("--duration",  type=float, default=-1, help="duration of the blink in seconds. Negative value means no timeout, i.e. it will stop when the program is killed.")
+parser.add_argument("--duty_cycle",  type=float, default=0.5, help="duty cycle between 0 and 1")
 
 args = parser.parse_args()
 
@@ -73,29 +91,43 @@ args = parser.parse_args()
 signal.signal(signal.SIGTERM, signal_term_handler)
 signal.signal(signal.SIGINT, signal_term_handler)
 
-# Init GPIO mux for LED control
-subprocess.call("""
-echo 40 >/sys/class/gpio/export
-echo 214 >/sys/class/gpio/export
-echo 243 >/sys/class/gpio/export
-echo 261 >/sys/class/gpio/export
-echo high >/sys/class/gpio/gpio214/direction
-echo mode0 > /sys/kernel/debug/gpio_debug/gpio40/current_pinmux
-echo low >/sys/class/gpio/gpio243/direction
-echo high >/sys/class/gpio/gpio261/direction
-echo low >/sys/class/gpio/gpio214/direction""", shell=True)
+# Detect ACPI or SFI
+acpi =  os.path.isdir("/sys/firmware/acpi")
 
-# Save current LED value for reverting to proper state at exit
-try:
-    lf =  open("/sys/class/gpio/gpio40/value","r")
-    v = lf.read()
-    lf.close()
-    if v[0] == '0':
+if acpi:
+    set_line("TRI_STATE_ALL", 0)
+    set_line("SPI_CLK_SEL", 0)
+    set_line("MUX18_DIR", 1)
+    set_line("TRI_STATE_ALL", 0)
+    led = gpiod.Chip("gpiochip0").get_line(40)
+    led.request(consumer=led.owner().name(), type=gpiod.LINE_REQ_DIR_OUT)
+    if led.get_value() == 0:
         initial_led_state = "low"
     else:
         initial_led_state = "high"
-except:
-    print "Can't get current LED state"
+else:
+    # Init GPIO mux for LED control
+    subprocess.call("""
+    echo 40 >/sys/class/gpio/export
+    echo 214 >/sys/class/gpio/export
+    echo 243 >/sys/class/gpio/export
+    echo 261 >/sys/class/gpio/export
+    echo high >/sys/class/gpio/gpio214/direction
+    echo low >/sys/class/gpio/gpio243/direction
+    echo high >/sys/class/gpio/gpio261/direction
+    echo low >/sys/class/gpio/gpio214/direction""", shell=True)
+
+    # Save current LED value for reverting to proper state at exit
+    try:
+        lf = open("/sys/class/gpio/gpio40/value","r")
+        v = lf.read()
+        lf.close()
+        if v[0] == "0":
+            initial_led_state = "low"
+        else:
+            initial_led_state = "high"
+    except:
+        print("Can't get current LED state")
 
 # Blink LED
 if args.duration >= 0:

--- a/meta-intel-edison-distro/recipes-support/libgpiod/libgpiod.inc
+++ b/meta-intel-edison-distro/recipes-support/libgpiod/libgpiod.inc
@@ -1,0 +1,21 @@
+SUMMARY = "C library and tools for interacting with the linux GPIO character device"
+
+LICENSE = "LGPLv2.1+"
+LIC_FILES_CHKSUM = "file://COPYING;md5=2caced0b25dfefd4c601d92bd15116de"
+
+SRC_URI = "https://www.kernel.org/pub/software/libs/libgpiod/${BP}.tar.xz"
+
+inherit autotools pkgconfig
+
+# enable tools
+PACKAGECONFIG ?= "tools"
+
+PACKAGECONFIG[tests] = "--enable-tests,--disable-tests,kmod udev"
+PACKAGECONFIG[tools] = "--enable-tools,--disable-tools,"
+
+PACKAGES =+ " ${PN}-tools"
+
+FILES_${PN}-tools = "${bindir}/*"
+
+RRECOMMENDS_TOOLS = "${@bb.utils.contains('PACKAGECONFIG', 'tools', '${PN}-tools', '',d)}"
+RRECOMMENDS_${PN} += "${RRECOMMENDS_TOOLS}"

--- a/meta-intel-edison-distro/recipes-support/libgpiod/libgpiod_1.1.1.bb
+++ b/meta-intel-edison-distro/recipes-support/libgpiod/libgpiod_1.1.1.bb
@@ -1,0 +1,16 @@
+require libgpiod.inc
+
+DEPENDS += "autoconf-archive-native"
+
+SRC_URI[md5sum] = "e5e946cb01a35e5046a1a7a108d6a96d"
+SRC_URI[sha256sum] = "172fa1544ecb51f37533b3e67862298d50c0a5cc84975f3c0706dc15467f0dfd"
+
+PACKAGECONFIG[cxx] = "--enable-bindings-cxx,--disable-bindings-cxx"
+
+PACKAGECONFIG[python3] = "--enable-bindings-python,--disable-bindings-python,python3,python3-core"
+inherit ${@bb.utils.contains('PACKAGECONFIG', 'python3', 'python3native', '', d)}
+
+PACKAGES =+ "${PN}-python"
+FILES_${PN}-python = "${PYTHON_SITEPACKAGES_DIR}"
+RRECOMMENDS_PYTHON = "${@bb.utils.contains('PACKAGECONFIG', 'python3', '${PN}-python', '',d)}"
+RRECOMMENDS_${PN} += "${RRECOMMENDS_PYTHON}"


### PR DESCRIPTION
Hello, guys!

In this PR I propose to use a edison-image-minimal as a base for other images. This seems to be the cleanest solution for application meta-layers to depend on.

These layers then would have for example another my-awesome-application.bb image recipe with a `require recipes-core/images/edison-image-minimal.bb`. This has worked quite good for me for a while.

I'm eager to hear your thoughts.