### PR TITLE
edison-machine-id.service - drop the umount

### DIFF
--- a/meta-intel-edison-distro/recipes-core/systemd/files/edison-machine-id.service
+++ b/meta-intel-edison-distro/recipes-core/systemd/files/edison-machine-id.service
@@ -4,7 +4,6 @@ After=systemd-remount-fs.service
 
 [Service]
 Type=oneshot
-ExecStartPre=/bin/umount /etc/machine-id
 ExecStart=/bin/systemd-machine-id-setup
 ExecStartPost=/bin/systemctl disable edison-machine-id
 StandardOutput=journal+console


### PR DESCRIPTION
It always generates an error like
> umount: /etc/machine-id: not mounted.