### PR TITLE
For pierre

### DIFF
--- a/meta-intel-edison-bsp/conf/machine/edison.conf
+++ b/meta-intel-edison-bsp/conf/machine/edison.conf
@@ -27,4 +27,4 @@ KERNEL_MODULE_AUTOLOAD += " ledtrig-heartbeat"
 #KERNEL_MODULE_PROBECONF += "g_multi"
 
 ACPI_TABLES ?= "arduino.asl spidev.asl leds.asl"
-ACPI_FEATURES_edison ?= "uart_2w i2c"
+ACPI_FEATURES_edison ?= "uart_2w i2c i2s"

--- a/meta-intel-edison-bsp/conf/machine/edison.conf
+++ b/meta-intel-edison-bsp/conf/machine/edison.conf
@@ -26,5 +26,5 @@ KERNEL_MODULE_AUTOLOAD += " ledtrig-heartbeat"
 #module_conf_g_multi = "options g_multi file=/dev/mmcblk0p9 stall=0 idVendor=0x8087 idProduct=0x0A9E iProduct=Edison iManufacturer=Intel"
 #KERNEL_MODULE_PROBECONF += "g_multi"
 
-ACPI_TABLES ?= "arduino.asl spidev.asl leds.asl"
+ACPI_TABLES ?= "arduino.asl"
 ACPI_FEATURES_edison ?= "uart_2w i2c i2s"

--- a/meta-intel-edison-bsp/conf/machine/edison.conf
+++ b/meta-intel-edison-bsp/conf/machine/edison.conf
@@ -6,7 +6,7 @@
 # This sets compilation options close to what is used on android
 include conf/machine/include/tune-corei7.inc
 TUNE_CCARGS .= " -mstackrealign"
-DEFAULTTUNE = "corei7-32"
+#DEFAULTTUNE = "corei7-32"
 
 MACHINE_FEATURES = "bluetooth alsa pci serial usbgadget usbhost wifi x86 ext3"
 KERNEL_IMAGETYPE = "bzImage"
@@ -16,8 +16,7 @@ SERIAL_CONSOLES = "115200;ttyS2"
 UBOOT_MACHINE = "edison_defconfig"
 
 # this tells yocto to use the defconfig supplied with the kernel
-#KBUILD_DEFCONFIG="x86_64_defconfig"
-KBUILD_DEFCONFIG="i386_defconfig"
+KBUILD_DEFCONFIG="x86_64_defconfig"
 # this tells yocto to expand the defconfig, i.e. make defconfig
 KCONFIG_MODE="--alldefconfig"
 

--- a/meta-intel-edison-bsp/recipes-kernel/sof/sof-fw.bb
+++ b/meta-intel-edison-bsp/recipes-kernel/sof/sof-fw.bb
@@ -7,7 +7,7 @@ SRC_URI = "git://github.com/thesofproject/sof-bin.git;branch=stable-v1.5;protoco
 
 S = "${WORKDIR}/"
 
-LICENSE = "BSD3"
+LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://edison-firmware/LICENCE.Intel;md5=54b4f1a2dd35fd85bc7a1d4afa731b78"
 
 PV = "1.5"

--- a/meta-intel-edison-distro/recipes-core/images/edison-image.bb
+++ b/meta-intel-edison-distro/recipes-core/images/edison-image.bb
@@ -29,6 +29,7 @@ IMAGE_INSTALL_append = " sof-fw"
 # ALSA lib and utilities
 #IMAGE_INSTALL_append = " alsa-lib"
 IMAGE_INSTALL_append = " alsa-utils-alsamixer alsa-utils-alsactl alsa-utils-aplay alsa-utils-amixer"
+IMAGE_INSTALL_append = " alsa-utils-speakertest"
 
 # OOBE
 IMAGE_INSTALL_append = " run-timezone"


### PR DESCRIPTION
I don't want to pull this now. This is a branch for @plbossart to enable testing SOF on edison in response to the comment in PR #112

I tested this myself, but on top of my btrfs branch, running from the sdhc. That should not make a significant difference to building this and flashing it to emmc. I see the clock 2.40MHz and bytes arriving ~48kHz on TX. I did not check clock polarity or if the signals can actually drive a sound card.

The only strange thing is that the i2s signals are not visible until you do:
```
    gpioset `gpiofind TRI_STATE_ALL`=0
    gpioset `gpiofind TRI_STATE_ALL`=1
```

But we already do this directly after loading the arduino.aml table ([here](https://github.com/edison-fw/meta-acpi/blob/1c12e06d16b05cb600fa813e04f619ceb7c21801/recipes-bsp/acpi-tables/files/edison/acpi-tables-load#L11). Maybe sleep 0.1 is too short for the SOF to initialize?