### PR TITLE
Htop receipe rebase

### DIFF
--- a/meta-intel-edison-distro/recipes-support/htop/files/0001-Use-pkg-config.patch
+++ b/meta-intel-edison-distro/recipes-support/htop/files/0001-Use-pkg-config.patch
@@ -1,0 +1,39 @@
+We need to use pkg-config to find the ncurses library instead of the
+ncurses*-config applications.
+
+Signed-off-by: Paul Barker <pbarker@toganlabs.com>
+Signed-off-by: Robert Joslyn <robert.joslyn@redrectangle.org>
+
+Upstream-status: Inappropriate
+    (`ncurses*-config` can be used outside of OpenEmbedded)
+
+diff --git a/configure.ac b/configure.ac
+index 559dc4d..77aea22 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -185,10 +185,10 @@ m4_define([HTOP_CHECK_LIB],
+ 
+ AC_ARG_ENABLE(unicode, [AS_HELP_STRING([--enable-unicode], [enable Unicode support])], ,enable_unicode="yes")
+ if test "x$enable_unicode" = xyes; then
+-   HTOP_CHECK_SCRIPT([ncursesw6], [addnwstr], [HAVE_LIBNCURSESW], "ncursesw6-config",
+-    HTOP_CHECK_SCRIPT([ncursesw], [addnwstr], [HAVE_LIBNCURSESW], "ncursesw6-config",
+-     HTOP_CHECK_SCRIPT([ncursesw], [addnwstr], [HAVE_LIBNCURSESW], "ncursesw5-config",
+-      HTOP_CHECK_SCRIPT([ncurses], [addnwstr], [HAVE_LIBNCURSESW], "ncurses5-config",
++   HTOP_CHECK_SCRIPT([ncursesw6], [addnwstr], [HAVE_LIBNCURSESW], "pkg-config ncursesw6",
++    HTOP_CHECK_SCRIPT([ncursesw], [addnwstr], [HAVE_LIBNCURSESW], "pkg-config ncursesw6",
++     HTOP_CHECK_SCRIPT([ncursesw], [addnwstr], [HAVE_LIBNCURSESW], "pkg-config ncursesw5",
++      HTOP_CHECK_SCRIPT([ncurses], [addnwstr], [HAVE_LIBNCURSESW], "pkg-config ncurses5",
+        HTOP_CHECK_LIB([ncursesw6], [addnwstr], [HAVE_LIBNCURSESW],
+         HTOP_CHECK_LIB([ncursesw], [addnwstr], [HAVE_LIBNCURSESW],
+          HTOP_CHECK_LIB([ncurses], [addnwstr], [HAVE_LIBNCURSESW],
+@@ -201,8 +201,8 @@ if test "x$enable_unicode" = xyes; then
+          [AC_CHECK_HEADERS([ncurses/curses.h],[:],
+             [AC_CHECK_HEADERS([ncurses.h],[:],[missing_headers="$missing_headers $ac_header"])])])])
+ else
+-   HTOP_CHECK_SCRIPT([ncurses6], [refresh], [HAVE_LIBNCURSES], "ncurses6-config",
+-    HTOP_CHECK_SCRIPT([ncurses], [refresh], [HAVE_LIBNCURSES], "ncurses5-config",
++   HTOP_CHECK_SCRIPT([ncurses6], [refresh], [HAVE_LIBNCURSES], "pkg-config ncurses6",
++    HTOP_CHECK_SCRIPT([ncurses], [refresh], [HAVE_LIBNCURSES], "pkg-config ncurses5",
+      HTOP_CHECK_LIB([ncurses6],  [refresh], [HAVE_LIBNCURSES],
+       HTOP_CHECK_LIB([ncurses],  [refresh], [HAVE_LIBNCURSES],
+       missing_libraries="$missing_libraries libncurses"

--- a/meta-intel-edison-distro/recipes-support/htop/files/0001-Use-pkg-config.patch
+++ b/meta-intel-edison-distro/recipes-support/htop/files/0001-Use-pkg-config.patch
@@ -8,10 +8,10 @@ Upstream-status: Inappropriate
     (`ncurses*-config` can be used outside of OpenEmbedded)
 
 diff --git a/configure.ac b/configure.ac
-index 559dc4d..77aea22 100644
+index 2c4fc5b..d405c3d 100644
 --- a/configure.ac
 +++ b/configure.ac
-@@ -185,10 +185,10 @@ m4_define([HTOP_CHECK_LIB],
+@@ -204,10 +204,10 @@ m4_define([HTOP_CHECK_LIB],
  
  AC_ARG_ENABLE(unicode, [AS_HELP_STRING([--enable-unicode], [enable Unicode support])], ,enable_unicode="yes")
  if test "x$enable_unicode" = xyes; then
@@ -26,7 +26,7 @@ index 559dc4d..77aea22 100644
         HTOP_CHECK_LIB([ncursesw6], [addnwstr], [HAVE_LIBNCURSESW],
          HTOP_CHECK_LIB([ncursesw], [addnwstr], [HAVE_LIBNCURSESW],
           HTOP_CHECK_LIB([ncurses], [addnwstr], [HAVE_LIBNCURSESW],
-@@ -201,8 +201,8 @@ if test "x$enable_unicode" = xyes; then
+@@ -220,8 +220,8 @@ if test "x$enable_unicode" = xyes; then
           [AC_CHECK_HEADERS([ncurses/curses.h],[:],
              [AC_CHECK_HEADERS([ncurses.h],[:],[missing_headers="$missing_headers $ac_header"])])])])
  else

--- a/meta-intel-edison-distro/recipes-support/htop/htop_2.2.0.bb
+++ b/meta-intel-edison-distro/recipes-support/htop/htop_2.2.0.bb
@@ -1,0 +1,35 @@
+SUMMARY = "Interactive process viewer"
+HOMEPAGE = "http://hisham.hm/htop"
+SECTION = "console/utils"
+LICENSE = "GPLv2"
+LIC_FILES_CHKSUM = "file://COPYING;md5=c312653532e8e669f30e5ec8bdc23be3"
+
+DEPENDS = "ncurses"
+
+SRC_URI = "http://hisham.hm/htop/releases/${PV}/${BP}.tar.gz \
+           file://0001-Use-pkg-config.patch"
+SRC_URI[md5sum] = "0d816b6beed31edc75babcfbf863ffa8"
+SRC_URI[sha256sum] = "d9d6826f10ce3887950d709b53ee1d8c1849a70fa38e91d5896ad8cbc6ba3c57"
+
+inherit autotools pkgconfig
+
+PACKAGECONFIG ??= "proc \
+                   cgroup \
+                   taskstats \
+                   unicode \
+                   linux-affinity \
+                   delayacct"
+PACKAGECONFIG[proc] = "--enable-proc,--disable-proc"
+PACKAGECONFIG[openvz] = "--enable-openvz,--disable-openvz"
+PACKAGECONFIG[cgroup] = "--enable-cgroup,--disable-cgroup"
+PACKAGECONFIG[vserver] = "--enable-vserver,--disable-vserver"
+PACKAGECONFIG[taskstats] = "--enable-taskstats,--disable-taskstats"
+PACKAGECONFIG[unicode] = "--enable-unicode,--disable-unicode"
+PACKAGECONFIG[linux-affinity] = "--enable-linux-affinity,--disable-linux-affinity"
+PACKAGECONFIG[hwloc] = "--enable-hwloc,--disable-hwloc,hwloc"
+PACKAGECONFIG[setuid] = "--enable-setuid,--disable-setuid"
+PACKAGECONFIG[delayacct] = "--enable-delayacct,--disable-delayacct,libnl"
+
+do_configure_prepend () {
+    rm -rf ${S}/config.h
+}

--- a/meta-intel-edison-distro/recipes-support/htop/htop_2.2.0.bb
+++ b/meta-intel-edison-distro/recipes-support/htop/htop_2.2.0.bb
@@ -1,15 +1,16 @@
 SUMMARY = "Interactive process viewer"
-HOMEPAGE = "http://hisham.hm/htop"
+HOMEPAGE = "https://htop.dev"
 SECTION = "console/utils"
 LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=c312653532e8e669f30e5ec8bdc23be3"
 
 DEPENDS = "ncurses"
 
-SRC_URI = "http://hisham.hm/htop/releases/${PV}/${BP}.tar.gz \
+SRCREV = "04cc193e3c0c39ea47eb01d61a6866b32d70baea"
+SRC_URI = "git://github.com/htop-dev/htop.git \
            file://0001-Use-pkg-config.patch"
-SRC_URI[md5sum] = "0d816b6beed31edc75babcfbf863ffa8"
-SRC_URI[sha256sum] = "d9d6826f10ce3887950d709b53ee1d8c1849a70fa38e91d5896ad8cbc6ba3c57"
+
+S = "${WORKDIR}/git"
 
 inherit autotools pkgconfig
 


### PR DESCRIPTION
This pull-request solves the problem described in the https://github.com/edison-fw/meta-intel-edison/issues/119.
The added recipe extracts the sources from the current repository of the "htop" project instead of the broken link specified in the recipe of meta-openembedded/meta-oe/recipes-support/htop/htop_2.2.0.bb