### PR TITLE
remove sudo requirement from DFU operations

### DIFF
--- a/docs/_docs/Edison/Building/2.0-Building-and-installing-the-image.md
+++ b/docs/_docs/Edison/Building/2.0-Building-and-installing-the-image.md
@@ -36,11 +36,11 @@ The results of bitbake will be found in `out/current/build/tmp/deploy/images/edi
 You need to connect the Edison Arduino using 2 USB cables and **the switch in the position** as in [Flashing only U-Boot](2.3-Building-and-flashing-U-boot.html#flashing-only-u-boot) step 1 - 3. 
 
 ### Flashall
-Change to the directory holding the flash-able image `out/linux64/build/toFlash/` and run `flashall.sh` as root and press the Edison Arduino RESET button when instructed to plug the cable:
+Change to the directory holding the flash-able image `out/linux64/build/toFlash/` and run `flashall.sh`. Press the Edison Arduino RESET button when instructed to plug the cable:
 ```
-sudo ./flashall.sh
+./flashall.sh
 ```
-Note 1: Despite Intel instruction to the contrary, we found on Ubuntu it is required to run `flashall.sh` as root.
+Note 1: If you have not followed the instructions in [Avoiding Permissions Issues](1.1-Prerequisites-for-building.html#avoiding-permissions-issues), you will need to invoke `flashall.sh` as root (i.e. `sudo ./flashall.sh`)
 
 Note 2: Many people have been reporting that the windows version `flashall.bat` is not working on Windows 10. Apparently these problems do not occur using `Flash Tool Lite`. 
 

--- a/docs/_docs/Edison/Building/2.3-Building-and-flashing-U-boot.md
+++ b/docs/_docs/Edison/Building/2.3-Building-and-flashing-U-boot.md
@@ -9,6 +9,9 @@ product: Edison
 ## Building U-Boot using Yocto
 U-Boot is built automatically as part of the image building, see [Building and installing the image](2.0-Building-and-installing-the-image). The recipe will be provide the latest U-Boot with `acpi` patches provided if required by the kernel (see ACPI or no-ACPI).
 
+## Before flashing anything
+The instructions on this page assume you have followed the instructions at [Avoiding Permissions Issues](1.1-Prerequisites-for-building.html#avoiding-permissions-issues). If you have not handled the permissions issues systematically via udev, you will need to invoke any instance of `flashall.sh` or `dfu-util` as root with `sudo`.
+
 ## Flashing everything
 To flash everything you use either the script `flashall.sh` or the [Intel Flash Tools Lite](https://01.org/node/2463). This replaces U-Boot, the kernel in the boot partition, U-Boot environment and the rootfs.
 
@@ -45,7 +48,7 @@ To flash the Edison Arduino board you need 2 USB connections.
 
 8.  In a second terminal window:
 
-        sudo dfu-util -v -d 8087:0a99 --alt u-boot0 -D u-boot.bin
+        dfu-util -v -d 8087:0a99 --alt u-boot0 -D u-boot.bin
 
     This will flash u-boot to the u-boot0 partition. In the first terminal window you may watch the flashing to complete.
 
@@ -64,26 +67,26 @@ If you find `OEMB ifwi version : 237.011` you need to update, with `OEMB ifwi ve
 You can manually update IFWI by performing the following commands in addition to step 8 above:
 
 ```
-sudo dfu-util -v -d 8087:0a99 --alt ifwi00 -D "edison_ifwi-dbg-00-dfu.bin"
-sudo dfu-util -v -d 8087:0a99 --alt ifwib00 -D "edison_ifwi-dbg-00-dfu.bin"
+dfu-util -v -d 8087:0a99 --alt ifwi00 -D "edison_ifwi-dbg-00-dfu.bin"
+dfu-util -v -d 8087:0a99 --alt ifwib00 -D "edison_ifwi-dbg-00-dfu.bin"
 
-sudo dfu-util -v -d 8087:0a99 --alt ifwi01 -D "edison_ifwi-dbg-01-dfu.bin"
-sudo dfu-util -v -d 8087:0a99 --alt ifwib01 -D "edison_ifwi-dbg-01-dfu.bin"
+dfu-util -v -d 8087:0a99 --alt ifwi01 -D "edison_ifwi-dbg-01-dfu.bin"
+dfu-util -v -d 8087:0a99 --alt ifwib01 -D "edison_ifwi-dbg-01-dfu.bin"
  
-sudo dfu-util -v -d 8087:0a99 --alt ifwi02 -D "edison_ifwi-dbg-02-dfu.bin"
-sudo dfu-util -v -d 8087:0a99 --alt ifwib02 -D "edison_ifwi-dbg-02-dfu.bin"
+dfu-util -v -d 8087:0a99 --alt ifwi02 -D "edison_ifwi-dbg-02-dfu.bin"
+dfu-util -v -d 8087:0a99 --alt ifwib02 -D "edison_ifwi-dbg-02-dfu.bin"
 
-sudo dfu-util -v -d 8087:0a99 --alt ifwi03 -D "edison_ifwi-dbg-03-dfu.bin"
-sudo dfu-util -v -d 8087:0a99 --alt ifwib03 -D "edison_ifwi-dbg-03-dfu.bin"
+dfu-util -v -d 8087:0a99 --alt ifwi03 -D "edison_ifwi-dbg-03-dfu.bin"
+dfu-util -v -d 8087:0a99 --alt ifwib03 -D "edison_ifwi-dbg-03-dfu.bin"
  
-sudo dfu-util -v -d 8087:0a99 --alt ifwi04 -D "edison_ifwi-dbg-04-dfu.bin"
-sudo dfu-util -v -d 8087:0a99 --alt ifwib04 -D "edison_ifwi-dbg-04-dfu.bin"
+dfu-util -v -d 8087:0a99 --alt ifwi04 -D "edison_ifwi-dbg-04-dfu.bin"
+dfu-util -v -d 8087:0a99 --alt ifwib04 -D "edison_ifwi-dbg-04-dfu.bin"
 
-sudo dfu-util -v -d 8087:0a99 --alt ifwi05 -D "edison_ifwi-dbg-05-dfu.bin"
-sudo dfu-util -v -d 8087:0a99 --alt ifwib05 -D "edison_ifwi-dbg-05-dfu.bin"
+dfu-util -v -d 8087:0a99 --alt ifwi05 -D "edison_ifwi-dbg-05-dfu.bin"
+dfu-util -v -d 8087:0a99 --alt ifwib05 -D "edison_ifwi-dbg-05-dfu.bin"
  
-sudo dfu-util -v -d 8087:0a99 --alt ifwi06 -D "edison_ifwi-dbg-06-dfu.bin"
-sudo dfu-util -v -d 8087:0a99 --alt ifwib06 -D "edison_ifwi-dbg-06-dfu.bin"
+dfu-util -v -d 8087:0a99 --alt ifwi06 -D "edison_ifwi-dbg-06-dfu.bin"
+dfu-util -v -d 8087:0a99 --alt ifwib06 -D "edison_ifwi-dbg-06-dfu.bin"
 ```
 
 ## Fixing up the u-boot environment

--- a/docs/_docs/Edison/Building/2.6-Building-Debian.md
+++ b/docs/_docs/Edison/Building/2.6-Building-Debian.md
@@ -22,7 +22,7 @@ During the process, you will be also asked to create the root password for Ediso
 
 You can type `make clean_debian` to delete the Debian image. It is required before calling `make debian` again.
 ### Installing
-Use `sudo out/linux64/build/toFlash/flashall.sh` to flash it or use Flash Tool Lite.
+Use `out/linux64/build/toFlash/flashall.sh` to flash it or use Flash Tool Lite.
 
 You can also choose to install the rootfs on the sd card or usb same as with the Yocto images.  
 

--- a/docs/_docs/Edison/Moving to btrfs/6.1-How-to-switch-to-btrfs.md
+++ b/docs/_docs/Edison/Moving to btrfs/6.1-How-to-switch-to-btrfs.md
@@ -180,6 +180,8 @@ make postbuild
 ```
 will rearrange so that the image contains `@`, `@modules` and `@home` subvolumes.
 
+The following steps require accessing the Edison using DFU. If you have not followed the instructions in [Avoiding Permissions Issues](1.1-Prerequisites-for-building.html#avoiding-permissions-issues), you will need to invoke `dfu-util` as root with sudo each time.
+
 To flash the Edison Arduino board you need 2 USB connections.
 
 1.  Connect the first USB cable to the USB port marked as 3 in the photograph below.  
@@ -205,7 +207,7 @@ To flash the Edison Arduino board you need 2 USB connections.
 
 8.  In a second terminal window:
     ```
-    sudo dfu-util -v -d 8087:0a99 --alt rootfs -D edison-image-edison.btrfs
+    dfu-util -v -d 8087:0a99 --alt rootfs -D edison-image-edison.btrfs
     ```
 
     This will flash the image to the rootfs partition. In the first terminal window you may watch the flashing to complete.
@@ -216,8 +218,8 @@ To flash the Edison Arduino board you need 2 USB connections.
 ```
     Now flash the btrfs enabled U-Boot environment and it's backup and reboot
 ```
-    sudo dfu-util -v -d 8087:0a99 --alt u-boot-env0 -D edison-btrfs.bin
-    sudo dfu-util -v -d 8087:0a99 --alt u-boot-env1 -D edison-btrfs.bin -R
+    dfu-util -v -d 8087:0a99 --alt u-boot-env0 -D edison-btrfs.bin
+    dfu-util -v -d 8087:0a99 --alt u-boot-env1 -D edison-btrfs.bin -R
 ```
 
 ### 8 - 12. Move `home` to `rootfs/@home`

--- a/docs/_docs/Edison/Setting Up/1.1-Prerequisites-for-building.md
+++ b/docs/_docs/Edison/Setting Up/1.1-Prerequisites-for-building.md
@@ -92,6 +92,26 @@ ferry@first:~$ sudo apt-get install gawk wget git-core diffstat unzip texinfo gc
 ```
 To get access to the files in the container use `scp`, `sshfs` or if you are using KDE's `Dolphin` the `fish` kioslave.
 
+## Avoiding Permissions Issues
+After a sucessful build process, there are a number of artifacts which must be transferred to the Edison via the Direct Firmware Update (DFU) protocol. By default, USB devices which expose a DFU interface are not directly accessible to non-root users. This can be corrected by a udev rule which identifies a particular device (in this case an Edison) and assigns permissions more appropriate for user access. 
+The following command will create a file and populate it with such a rule. The tee command requires sudo, as the file it creates is in a directory owned by root. The rule specifically identifies the ID numbers associated with an Edison in DFU mode, and makes the device read/writeable by members of the `plugdev` group. 
+```
+echo SUBSYSTEM==\"usb\", ATTRS{idVendor}==\"8087\", ATTRS{idProduct}==\"0a99\", MODE=\"0664\", GROUP=\"plugdev\" | sudo tee /etc/udev/rules.d/46-edison-dfu.rules
+```
+It may be necessary to reload the udev system for the rule to take effect.
+```
+sudo udevadm control --reload-rules && udevadm trigger
+```
+You will also need to verify that your user is a member of the `plugdev` group.
+```
+groups | grep plugdev
+```
+If nothing is returned, then you will need to add your user to the `plugdev` group.
+```
+sudo usermod -aG plugdev ${USER}
+```
+Log out and log back in for changes to take effect.
+
 ## Building under Windows (10)
 
 ### Ubuntu for Windows

--- a/utils/debian_2_mkimage.sh
+++ b/utils/debian_2_mkimage.sh
@@ -84,7 +84,7 @@ fi
 
 rmdir tmpbtrfs
 
-#cp edison-image-edison.btrfs toFlash/
+cp edison-image-edison.btrfs toFlash/
 # Make sure that non-root users can read write the flash files
 # This seems to fix a strange flashing issue in some cases
 sudo chmod -R a+rw toFlash


### PR DESCRIPTION
Things to note:
I am 90% sure I did the markdown links correctly. Perhaps you have a way to test those short of putting them online?
I left the invocations of `flashall.sh --recovery` with sudo as before. That uses the xFSTK tool, and I am not sure that the udev rule will help with that operation.