### PR TITLE
oobe_git.bb - configure_edison - re-introduce empty var dir

### DIFF
--- a/meta-intel-edison-distro/recipes-support/oobe/oobe_git.bb
+++ b/meta-intel-edison-distro/recipes-support/oobe/oobe_git.bb
@@ -3,7 +3,7 @@ LICENSE = "MIT"
 
 SRC_URI = "git://github.com/edison-fw/edison-oobe;protocol=https"
 
-SRCREV = "6daba9fe150d0026ae8b79447bd576770cd9f965"
+SRCREV = "07512dfcb97d77c57adb024c6ca3473abbae0229"
 PV = "1.2.1+git${SRCPV}"
 
 LIC_FILES_CHKSUM = "file://LICENSE;md5=ea398a763463b76b18da15f013c0c531"

--- a/meta-intel-edison-distro/recipes-support/oobe/oobe_git.bb
+++ b/meta-intel-edison-distro/recipes-support/oobe/oobe_git.bb
@@ -14,6 +14,7 @@ RDEPENDS_${PN} = "python3-core python3-bottle"
 
 do_install() {
    install -d ${D}${libdir}/edison_config_tools
+   install -d ${D}/var/lib/edison_config_tools
    cp -r ${S}/src/public ${D}${libdir}/edison_config_tools
    install -d ${D}${systemd_unitdir}/system/
    install -m 0644 ${S}/src/edison_config.service ${D}${systemd_unitdir}/system/
@@ -28,6 +29,7 @@ SYSTEMD_SERVICE_${PN} = "edison_config.service"
 
 FILES_${PN} = "${libdir}/edison_config_tools \
                ${systemd_unitdir}/system \
+               /var/lib/edison_config_tools \
                ${bindir}/"
 
 PACKAGES = "${PN}"


### PR DESCRIPTION
Initially empty, but after the setup it gets filled by certain state files e.g. "password_setup.done".