### PR TITLE
docs: add pre-built ubuntu image link

### DIFF
--- a/docs/_docs/Edison/Building/2.7-Install_Ubuntu.md
+++ b/docs/_docs/Edison/Building/2.7-Install_Ubuntu.md
@@ -6,6 +6,8 @@ product: Edison
 ---
 Instead of having `make` build a Debian image, here are the instructions to manually modify a Ubuntu Base image to make it bootable on Intel Edison. 
 
+Also here is a pre-built ubuntu image for you now! check [ubuntu-22.04-minimal](https://github.com/initdc/rootfs-tools/releases/tag/22.04)
+
 ### Step 1
 Download Gatesgarth64 image (https://github.com/edison-fw/meta-intel-edison/releases/download/Gatesgarth64/edison-image-91c85a58.7z).<br>
 Use `flashall.sh` to flash it on the Edison.

--- a/docs/_docs/Edison/Building/2.7-Install_Ubuntu.md
+++ b/docs/_docs/Edison/Building/2.7-Install_Ubuntu.md
@@ -58,7 +58,8 @@ Install some necessary packages:<br>
 <br>`apt install -y language-pack-en-base`
 <br>`apt install -y dialog apt-utils`
 <br>`unset DEBIAN_FRONTEND`
-<br>`apt install -y kmod wpasupplicant rfkill ifupdown iputils-ping dnsutils wireless-tools bash-completion vim htop wget curl tree openssh-server systemd systemd-sysv sudo net-tools nano`
+<!-- sorting by https://build.moz.one -->
+<br>`apt install -y bash-completion curl dnsutils htop ifupdown iputils-ping kmod nano net-tools network-manager openssh-server rfkill sudo systemd systemd-sysv tree vim wget wireless-tools wpasupplicant`
 
 ### Step 12
 Create an user, and set password:

--- a/utils/debian_1_create.sh
+++ b/utils/debian_1_create.sh
@@ -5,10 +5,8 @@ echo === Generating debian folder ===
 echo ================================
 
 ROOTDIR=$1
-if [ -z "$ROOTDIR" ]
-then
-echo "Select a distribution" ||
-exit 1
+if [ -z "$ROOTDIR" ]; then
+    echo "Select a distribution" || exit 1
 fi
 
 cd out/linux64/build
@@ -19,7 +17,11 @@ sudo mkdir -p $ROOTDIR/home/root
 
 LC_ALL=C LANGUAGE=C LANG=C sudo chroot $ROOTDIR /bin/bash -c "apt clean"
 LC_ALL=C LANGUAGE=C LANG=C sudo chroot $ROOTDIR /bin/bash -c "apt update"
-LC_ALL=C LANGUAGE=C LANG=C sudo chroot $ROOTDIR /bin/bash -c "apt install -y wpasupplicant rfkill vim ssh sudo connman parted cloud-guest-utils net-tools"
+# sorting by https://build.moz.one
+LC_ALL=C LANGUAGE=C LANG=C sudo chroot $ROOTDIR /bin/bash -c "apt install -y  \
+    bash-completion cloud-guest-utils connman curl dnsutils htop ifupdown  \
+    iputils-ping kmod nano net-tools network-manager openssh-server parted rfkill  \
+    ssh sudo systemd systemd-sysv tree vim wget wireless-tools wpasupplicant"
 
 sudo cp -r tmp/deploy/deb $ROOTDIR/tmp/
 sudo cp -r ../../../meta-intel-edison/meta-intel-edison-distro/recipes-core/base-files/base-files/fstab.btrfs $ROOTDIR/etc/fstab
@@ -32,7 +34,7 @@ sudo chroot $ROOTDIR /bin/bash -c "dpkg -i /tmp/deb/corei7-64/gadget_*.deb"
 sudo rm -rf $ROOTDIR/tmp/*
 
 sudo rm -f $ROOTDIR/etc/hostname
-sudo echo edison > $ROOTDIR/etc/hostname
+sudo echo edison >$ROOTDIR/etc/hostname
 
 sudo rm -f $ROOTDIR/etc/resolv.conf
 sudo ln -s /run/connman/resolv.conf /$ROOTDIR/etc/resolv.conf


### PR DESCRIPTION
- Page preview: https://initdc.github.io/meta-intel-edison/2.7-Install_Ubuntu.html

- Image : 
  1. link: https://github.com/initdc/rootfs-tools/releases/tag/22.04
  2. info:
    For Intel Edison 
    Base on https://github.com/edison-fw/meta-intel-edison/releases/tag/hardknott and [ubuntu-22.04-minimal-cloudimg-amd64-root.tar.xz](https://cloud-images.ubuntu.com/minimal/releases/jammy/release/ubuntu-22.04-minimal-cloudimg-amd64-root.tar.xz)

    user
    `root/root`
    `ubuntu/ubuntu`
    
    login and run
    `sudo modprobe brcmfmac`