### PR TITLE
Minor fixes to the documentation

### DIFF
--- a/docs/_docs/Edison/Setting Up/1.1-Prerequisites-for-building.md
+++ b/docs/_docs/Edison/Setting Up/1.1-Prerequisites-for-building.md
@@ -29,7 +29,7 @@ Yocto Hardknott will build on Ubuntu Impish (21.10).
 Install the required build environment:
 
     sudo apt-get install gawk wget git-core diffstat unzip texinfo gcc-multilib build-essential chrpath socat cpio python python3 libsdl1.2-dev xterm
-    sudo apt-get install python-is-python2 p7zip-full btrfs-tools
+    sudo apt-get install python-is-python2 p7zip-full btrfs-progs
 
 ## Building the Hardknott branche from an Ubuntu LTS container (Bionic)
 {% include note.html content="These instructions are based on [Linux Containers](https://linuxcontainers.org/lxd/getting-started-cli/) but with additional configuration (`ssh` access) that you will likely need to build Yocto." %}

--- a/docs/_docs/Edison/Setting Up/1.2-Setting-up.md
+++ b/docs/_docs/Edison/Setting Up/1.2-Setting-up.md
@@ -12,7 +12,7 @@ product: Edison
 
         mkdir my_Edison_Workspace
 		
-		cd my_Edison_Workspace
+	cd my_Edison_Workspace
 
 2- Get this layer:
 

--- a/docs/_docs/Edison/Setting Up/1.2-Setting-up.md
+++ b/docs/_docs/Edison/Setting Up/1.2-Setting-up.md
@@ -11,6 +11,8 @@ product: Edison
 1- Prepare your workspace:
 
         mkdir my_Edison_Workspace
+		
+		cd my_Edison_Workspace
 
 2- Get this layer:
 


### PR DESCRIPTION
Changed btrfs-tools package to btrfs-progs because it seems to have changed name (btrfs-tools no more exists).
Added "cd my_Edison_Workspace" otherwise you were creating the build directory without using it and everything would have compiled in your home dir