### PR TITLE
Update oobe_git.bb

### DIFF
--- a/meta-intel-edison-distro/recipes-support/oobe/oobe_git.bb
+++ b/meta-intel-edison-distro/recipes-support/oobe/oobe_git.bb
@@ -17,6 +17,9 @@ do_compile() {
     # changing the home directory to the working directory, the .npmrc will be created in this directory
     export HOME=${WORKDIR}
 
+    # Roll back to the last commit that was compatible with Sumo32 (no python3, still has server.js)
+    git checkout 250de53880e4627e79f42b30a0db132b0bba3347
+
     # does not build dev packages
     npm config set dev false
 


### PR DESCRIPTION
Since Sumo32 is frozen in time & the current oobe source doesn't work with it, have this recipe use the last version that it knows how to build correctly (and that doesn't have post-Sumo dependencies - eg python3) 

This, along with a change to the URL for the ACPI support package, allows it to build again.

Doing this because there are still some things 'out there' that use MRAA & the Edison - most of them running on 3.x Linux kernels... Making sumo32 build again makes it easier to use it's kernel image. 