### PR TITLE
Correct Ubuntu version for Yocto Scarthgap build

### DIFF
--- a/docs/_docs/Edison/Setting Up/1.1-Prerequisites-for-building.md
+++ b/docs/_docs/Edison/Setting Up/1.1-Prerequisites-for-building.md
@@ -26,7 +26,7 @@ The serial_number can be reclaimed from the label on the Intel Edison, but the b
 
 ## Building the Scarthgap branche on Ubuntu Noble
 
-Yocto Scarthgap will build on Ubuntu Noble (24.10).
+Yocto Scarthgap will build on Ubuntu Noble (24.04).
 
 Install the required build environment:
 


### PR DESCRIPTION
Had an incorrect ubuntu version (24.10 instead of 24.04) for Ubuntu Noble. Changed it in the markdown file.